### PR TITLE
Verify provider version

### DIFF
--- a/lib/assets.ts
+++ b/lib/assets.ts
@@ -13,7 +13,7 @@ const AssetHashes: Record<string, IAssetHash> = {
     [NetworkNames.TESTNET]:
       '0d86b2f6a8c3b02a8c7c8836b83a081e68b7e2b4bcdfc58981fc5486f59f7518',
     [NetworkNames.MAINNET]:
-      '518c0b351f5731f5d40cf6ad444d1c147eda1cdf8c867185c58a526fb02ad806',
+      '0dea022a8a25abb128b42b0f8e98532bc8bd74f8a77dc81251afcc13168acef7',
   },
   LBTC: {
     [NetworkNames.MAINNET]:

--- a/lib/tdex/registry.ts
+++ b/lib/tdex/registry.ts
@@ -17,6 +17,21 @@ function getRegistryURL(network: NetworkNames): string {
   return Registries[network] || Registries[NetworkNames.MAINNET]
 }
 
+async function respondsWithCorrectVersion(
+  provider: TDEXv2Provider,
+): Promise<boolean> {
+  try {
+    const url = provider.endpoint + '/v1/info'
+    const res = await axios.post(url, { list_services: '' })
+    return res.data.result.listServicesResponse.service
+      .map((s: { name: string }) => s.name)
+      .includes('tdex.v2.TradeService')
+  } catch (error) {
+    console.error(error)
+    return false
+  }
+}
+
 /**
  * Get a list of registered providers from TDEX_REGISTRY_URL
  * @param network network name
@@ -27,5 +42,5 @@ export async function getProvidersFromRegistry(
 ): Promise<TDEXv2Provider[]> {
   const res = (await axios.get(getRegistryURL(network))).data
   if (!Array.isArray(res)) throw TradeStatusMessage.InvalidRegistry
-  return res.filter(isTDEXv2Provider)
+  return res.filter(isTDEXv2Provider).filter(respondsWithCorrectVersion)
 }


### PR DESCRIPTION
Change FUJI mainnet asset hash from Test-FUSD (`518c`) to FUSD (`0dea`) 🤦 

Check if providers from registry respond to TDEX v2, by POSTing to `/v1/info` and parsing the response.

@altafan please review
